### PR TITLE
Approximate matching of UIDs

### DIFF
--- a/pyrates/clustering.py
+++ b/pyrates/clustering.py
@@ -56,7 +56,7 @@ class Clustering(object):
         with open_fun(input_file) as fastq:
             for (line_count, line) in enumerate(fastq):
                 # print out some stats as we go
-                if cls._logger.isEnabledFor(logging.DEBUG) and (line_count % 100000) == 0:
+                if cls._logger.isEnabledFor(logging.DEBUG) and (line_count % 1000) == 0:
                     cls._logger.debug("reads: %d clusters: %d merged: %d skipped: %d",
                                       line_count/4, len(seq), total_merged, total_skipped)
                 elif (line_count % 4) == 1:
@@ -73,9 +73,13 @@ class Clustering(object):
                     if nameid in id_map:
                         nameid = id_map[nameid]
                         total_merged += 1
-                    if nameid not in seq:
+                    elif nameid not in seq:
+                        ## Look for similar IDs that may be candidates for merging
                         similar_id = id_set.find(nameid, threshold)
-                        if similar_id is None:
+                        ## Check that there are no obvious differences between sequences
+                        if similar_id is None or \
+                          len(seq[similar_id].sequence) != len(read_seq) or \
+                          seq[similar_id].sequence.grosslydifferent(read_seq):
                             seq[nameid] = cons.Consensus(uid, read_seq)
                             id_set.add(nameid)
                             continue

--- a/pyrates/clustering.py
+++ b/pyrates/clustering.py
@@ -43,7 +43,6 @@ class Clustering(object):
         Returns:
             :obj:`dict`: Computed consensus sequences.
         """
-        line_count = 0
         total_skipped = 0
         total_merged = 0
         seq = {}
@@ -55,7 +54,7 @@ class Clustering(object):
 
         open_fun = utils.smart_open(input_file)
         with open_fun(input_file) as fastq:
-            for line in fastq:
+            for (line_count, line) in enumerate(fastq):
                 # print out some stats as we go
                 if cls._logger.isEnabledFor(logging.DEBUG) and (line_count % 100000) == 0:
                     cls._logger.debug("reads: %d clusters: %d merged: %d skipped: %d",
@@ -87,7 +86,6 @@ class Clustering(object):
                     success = seq[nameid].update(uid, read_seq)
                     if not success:
                         total_skipped += 1
-                line_count += 1
         return cls(seq, id_set)
 
     def find(self, uid, tolerance=3):

--- a/pyrates/cmd_consensus.py
+++ b/pyrates/cmd_consensus.py
@@ -102,14 +102,6 @@ def main():
                     total_shorter)
         logger.info("Number of sequences that were longer then consensus sequence %d",
                     total_longer)
-        cons_time = time.time()
-        logger.info('Time taken for consensus: %s',
-                    str(datetime.timedelta(seconds=cons_time - started_at)))
-    seq.merge(args.id_tolerance, args.merge_size)
-    if args.merge_size and args.merge_target:
-        logger.info('Time taken for merging: %s',
-                    str(datetime.timedelta(seconds=time.time() - cons_time)))
-    seq.write(args.output)
     logger.info('Total time taken: %s', str(datetime.timedelta(seconds=time.time() - started_at)))
     mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
     logger.info('Memory used: %.2f MB', mem)

--- a/pyrates/consensus.py
+++ b/pyrates/consensus.py
@@ -96,17 +96,12 @@ class Consensus(object):
                                self.uid.sequence, uid_other.sequence)
             return False
 
-        # if grossly different then just count this and move on
-        if self.sequence.grosslydifferent(seq_other):
-            if discard:
-                self.different += size_other
-            return False
-
         # if sequence length is shorter, count this occurance, abandon this
         # sequence and move on
         if len(self.sequence) > len(seq_other):
             if discard:
                 self.shorter += size_other
+            self._logger.debug("Mismatch in sequence length")
             return False
 
         # if new sequence is longer, count this occurance
@@ -117,7 +112,16 @@ class Consensus(object):
                     self.sequence = seq_other
                     self.shorter += size_other
                 else: self.longer += size_other
+            self._logger.debug("Mismatch in sequence length")
             return False
+
+        # if grossly different then just count this and move on
+        if self.sequence.grosslydifferent(seq_other):
+            if discard:
+                self.different += size_other
+            self._logger.debug("Sequences are too different")
+            return False
+
 
         self._update_uid(uid_other)
 


### PR DESCRIPTION
Instead of reading all the data first and trying to merge small clusters later, this identifies approximate matches for UIDs as they are read from the input file. Using this approach appears to be about twice as fast as the current post-processing.