### PR TITLE
Performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docker/requirements.txt
 .coverage
 tmp/*
 pyrates.prof
+pyrates.lprof

--- a/pyrates/clustering.py
+++ b/pyrates/clustering.py
@@ -2,6 +2,8 @@
 """
 
 import logging
+import time
+import datetime
 from collections import defaultdict
 import pyrates.utils as utils
 import pyrates.sequence as pseq
@@ -15,6 +17,8 @@ class Clustering(object):
             sequences and identified by the associated UID.
         store (:obj:`pyrates.sequence.SequenceStore`, optional): Precomputed set of UID sequences.
             If this is missing it will be computed from the cluster centres.
+        wildcard (:obj:`string`): Single character that should be treated as wildcard or
+                `None` to disable use of wildcard matching.
 
     Attributes:
         clusters (:obj:`dict`): Cluster centres represented by consensus
@@ -23,12 +27,13 @@ class Clustering(object):
     __slots__ = 'clusters', '_store'
     _logger = utils.get_logger(__name__)
 
-    def __init__(self, centres, store=None):
+    def __init__(self, centres, store=None, wildcard=None):
         self.clusters = centres
         if store is not None:
             self._store = store
         else:
-            self._store = pseq.SequenceStore.from_list(list(centres.keys()))
+            self._store = pseq.GroupedSequenceStore.from_list(list(centres.keys()),
+                                                              wildcard=wildcard)
 
     def _filter(self, pattern, candidates, read_seq):
         candidates = [cand for cand in candidates if
@@ -38,7 +43,7 @@ class Clustering(object):
         candidates = [(cand, pseq.SequenceStore.diff(cand, pattern)) for cand in candidates]
         return candidates
 
-    def merge_target(self, uid, read_seq, id_map, threshold, wildcard):
+    def merge_target(self, uid, read_seq, id_map, threshold):
         """Compute set of candidate clusters for a given read.
 
         Args:
@@ -46,15 +51,13 @@ class Clustering(object):
             read_seq (:obj:`pyrates.sequence.SequenceWithQuality`): Read sequence.
             id_map (:obj:`dictionary`): A mapping of known approximate matches for UIDs.
             threshold (:obj:`int`): Maximum number of differences allowed between UIDs.
-            wildcard (:obj:`string`): Single character that should be treated as wildcard or
-                `None` to disable use of wildcard matching.
 
         Returns:
             :obj:`string`: Either the best approximate match for the UID or `None`
                 if no valid match was found.
         """
         nameid = uid.sequence
-        id_cands = self._store.search(nameid, max_diff=threshold, raw=True, wildcard=wildcard)
+        id_cands = self._store.search(nameid, max_diff=threshold, raw=True)
         id_cands = self._filter(nameid, id_cands, read_seq)
         if id_cands:
             similar_id = min(id_cands, key=lambda x: x[1])
@@ -67,7 +70,7 @@ class Clustering(object):
         ## Create new cluster or merge with existing consensus
         if similar_id is None:
             self.clusters[nameid] = cons.Consensus(uid, read_seq)
-            self._store.add(nameid, wildcard=wildcard)
+            self._store.add(nameid)
         else:
             similar_id = similar_id
             id_map[nameid] = similar_id
@@ -88,19 +91,30 @@ class Clustering(object):
         total_skipped = 0
         total_merged = 0
 
-        id_set = pseq.SequenceStore(id_length*2)
-        id_wild = defaultdict(list)
+        id_set = pseq.GroupedSequenceStore(id_length*2, tag_size=threshold, wildcard='N')
         id_map = {}
         seq = cls({}, id_set)
 
         adapt_length = id_length + len(adapter)
         open_fun = utils.smart_open(input_file)
+        start_time = time.time()
+        batch_start = start_time
         with open_fun(input_file) as fastq:
             for (line_count, line) in enumerate(fastq):
                 # print out some stats as we go
-                if cls._logger.isEnabledFor(logging.DEBUG) and (line_count % 10000) == 0:
+                if cls._logger.isEnabledFor(logging.DEBUG) and line_count > 0 and \
+                        (line_count % 10000) == 0:
+                    checkpoint = time.time()
+                    total_time = checkpoint - start_time
+                    batch_time = checkpoint - batch_start
+                    batch_start = checkpoint
                     cls._logger.debug("reads: %d clusters: %d merged: %d skipped: %d",
                                       line_count/4, len(seq), total_merged, total_skipped)
+                    cls._logger.debug("total time: %s, increment: %s, rate: %.1f reads/s",
+                                      datetime.timedelta(seconds=total_time),
+                                      datetime.timedelta(seconds=batch_time),
+                                      line_count/4/total_time)
+                    cls._logger.debug("fragmentation: %.2f%%", total_merged/(line_count/4.0)*100)
                 elif (line_count % 4) == 1:
                     line = line.rstrip("\n")
                     nameid = line[0:id_length] + line[-id_length:]
@@ -112,15 +126,12 @@ class Clustering(object):
 
                     uid = pseq.SequenceWithQuality(nameid, qnameid)
                     read_seq = pseq.SequenceWithQuality(sequence, qsequence)
-                    if nameid.count('N'):
-                        id_wild[nameid].append((uid, read_seq))
-                        continue
                     ## Look for similar IDs that may be candidates for merging
                     similar_id = None
                     if nameid in id_map:
                         similar_id = id_map[nameid]
                     elif nameid not in seq:
-                        similar_id = seq.merge_target(uid, read_seq, id_map, threshold, None)
+                        similar_id = seq.merge_target(uid, read_seq, id_map, threshold)
                     else:
                         similar_id = nameid
                     if similar_id is not None:
@@ -130,20 +141,7 @@ class Clustering(object):
                         else:
                             total_skipped += 1
                     else:
-                        seq.add(uid, read_seq, None)
-            for nameid in id_wild:
-                uid = id_wild[nameid][0][0]
-                for item in id_wild[nameid]:
-                    read_seq = item[1]
-                    similar_id = seq.merge_target(uid, read_seq, id_map, threshold, 'N')
-                    if similar_id is not None:
-                        success = seq[similar_id].update(uid, read_seq)
-                        if success:
-                            total_merged += 1
-                        else:
-                            total_skipped += 1
-                    else:
-                        seq.add(uid, read_seq, 'N')
+                        seq.add(uid, read_seq)
         return seq
 
     def write(self, output_file):
@@ -185,17 +183,16 @@ class Clustering(object):
         """Test for presence of UID"""
         return key in self.clusters
 
-    def add(self, uid, sequence, wildcard=None):
+    def add(self, uid, sequence):
         """Add a new cluster centre.
 
         Args:
             uid (:obj:`pyrates.sequence.SequenceWithQuality`): UID for the new cluster.
             sequence (:obj:`pyrates.sequence.SequenceWithQuality`): Sequence to represent cluster.
-            wildcard (:obj:`str`): Wildcard character to use, `None` to disable wildcard matching.
         """
         nameid = uid.sequence
         self.clusters[nameid] = cons.Consensus(uid, sequence)
-        self._store.add(nameid, wildcard)
+        self._store.add(nameid)
 
     def __contains__(self, item):
         return item in self.clusters

--- a/pyrates/clustering.py
+++ b/pyrates/clustering.py
@@ -35,7 +35,7 @@ class Clustering(object):
             self._store = pseq.GroupedSequenceStore.from_list(list(centres.keys()),
                                                               wildcard=wildcard)
 
-    def _filter(self, pattern, candidates, read_seq):
+    def _filter(self, pattern, candidates, read_seq, threshold):
         candidates = [cand for cand in candidates if
                       len(self[cand].sequence) == len(read_seq)]
         candidates = [cand for cand in candidates if

--- a/pyrates/clustering.py
+++ b/pyrates/clustering.py
@@ -72,7 +72,6 @@ class Clustering(object):
             self.clusters[nameid] = cons.Consensus(uid, read_seq)
             self._store.add(nameid)
         else:
-            similar_id = similar_id
             id_map[nameid] = similar_id
         return similar_id
 

--- a/pyrates/clustering.py
+++ b/pyrates/clustering.py
@@ -27,13 +27,20 @@ class Clustering(object):
     __slots__ = 'clusters', '_store'
     _logger = utils.get_logger(__name__)
 
-    def __init__(self, centres, store=None, wildcard=None):
+    def __init__(self, centres, store=None, wildcard=None,
+                 alphabet=('A', 'C', 'G', 'T'), tag_size=5, max_diff=3):
         self.clusters = centres
         if store is not None:
             self._store = store
-        else:
+        elif tag_size > 0:
             self._store = pseq.GroupedSequenceStore.from_list(list(centres.keys()),
+                                                              alphabet=alphabet,
+                                                              tag_size=tag_size,
+                                                              max_diff=max_diff,
                                                               wildcard=wildcard)
+        else:
+            self._store = pseq.SequenceStore.from_list(list(centres.keys()),
+                                                       alphabet=alphabet)
 
     def _filter(self, pattern, candidates, read_seq, threshold):
         candidates = [cand for cand in candidates if

--- a/pyrates/clustering.py
+++ b/pyrates/clustering.py
@@ -75,7 +75,7 @@ class Clustering(object):
         return similar_id
 
     @classmethod
-    def from_fastq(cls, input_file, id_length, adapter, threshold=5):
+    def from_fastq(cls, input_file, id_length, adapter, threshold=5, prefix=5):
         """Read FASTQ file to generate consensus sequences.
 
         Args:
@@ -91,7 +91,7 @@ class Clustering(object):
         total_fixed = 0
         single_count = 0
 
-        id_set = pseq.GroupedSequenceStore(id_length*2, tag_size=5, max_diff=threshold,
+        id_set = pseq.GroupedSequenceStore(id_length*2, tag_size=prefix, max_diff=threshold,
                                            wildcard='N')
         id_map = {}
         seq = cls({}, id_set)

--- a/pyrates/clustering.py
+++ b/pyrates/clustering.py
@@ -59,7 +59,7 @@ class Clustering(object):
                 if no valid match was found.
         """
         nameid = uid.sequence
-        id_cands = self._store.search(nameid, max_diff=threshold, max_hits=100, raw=True)
+        id_cands = self._store.search(nameid, max_hits=100, raw=True)
         id_cands = self._filter(nameid, id_cands, read_seq, threshold)
         if id_cands:
             similar_id = min(id_cands, key=lambda x: x[1])
@@ -91,7 +91,8 @@ class Clustering(object):
         total_fixed = 0
         single_count = 0
 
-        id_set = pseq.GroupedSequenceStore(id_length*2, tag_size=5, wildcard='N')
+        id_set = pseq.GroupedSequenceStore(id_length*2, tag_size=5, max_diff=threshold,
+                                           wildcard='N')
         id_map = {}
         seq = cls({}, id_set)
 

--- a/pyrates/cmd_consensus.py
+++ b/pyrates/cmd_consensus.py
@@ -54,7 +54,7 @@ def main():
     )
     parser.add_argument(
         '--id-tolerance',
-        default=5,
+        default=5, type=int,
         help='Maximum number of differences between IDs allowed to consider merging of clusters.'
     )
     parser.add_argument(
@@ -84,7 +84,7 @@ def main():
 
     ## start consensus computation
     started_at = time.time()
-    seq = clust.Clustering.from_fastq(args.fastq, args.id_length, args.adapter)
+    seq = clust.Clustering.from_fastq(args.fastq, args.id_length, args.adapter, args.id_tolerance)
 
     if logger.isEnabledFor(logging.INFO):
         total_different = 0
@@ -102,6 +102,8 @@ def main():
                     total_shorter)
         logger.info("Number of sequences that were longer then consensus sequence %d",
                     total_longer)
+        logger.info("Number of sequences with ambiguous label %d (%.2f%%)",
+                    seq.fail_count(), seq.fail_count()/len(seq)*100)
     logger.info('Total time taken: %s', str(datetime.timedelta(seconds=time.time() - started_at)))
     mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
     logger.info('Memory used: %.2f MB', mem)

--- a/pyrates/sequence.py
+++ b/pyrates/sequence.py
@@ -213,13 +213,16 @@ class SequenceStore(object):
         letter_count = sequence.count(letter)
         min_count = max(0, letter_count - max_diff)
         max_count = min(len(self._composition[letter]), letter_count + max_diff + wilds + 1)
-        candidates = set.union(*self._composition[letter][min_count:max_count])
+        candidates = []
+        for cand in self._composition[letter][min_count:max_count]:
+            candidates.extend(cand)
         for letter in self._alphabet[1:]:
             letter_count = sequence.count(letter)
             min_count = max(0, letter_count - max_diff)
             max_count = min(len(self._composition[letter]), letter_count + max_diff + wilds + 1)
-            candidates.intersection_update(
-                set.union(*self._composition[letter][min_count:max_count]))
+            for cand in self._composition[letter][min_count:max_count]:
+                candidates.extend(cand)
+        candidates = set(candidates)
         if raw:
             return candidates
         candidates = [(cand, self.diff(sequence, cand)) for cand in candidates]

--- a/pyrates/sequence.py
+++ b/pyrates/sequence.py
@@ -96,8 +96,6 @@ class SequenceStore(object):
     Args:
         max_length (:obj:`int`): Maximum sequence length supported by this store.
         alphabet (:obj:`tuple`): A list of all valid sequence characters.
-        wildcard (:obj:`string`): A character that should be treated as a wildcard,
-            i.e. match all letters in the alphabet.
     """
     __slots__ = '_alphabet', '_composition', '_index'
     _logger = utils.get_logger(__name__)
@@ -129,6 +127,7 @@ class SequenceStore(object):
 
         Args:
             sequence (:obj:`string`): New sequence to be added.
+            wildcard (:obj:`string`): Character that should be treated as wildcard.
         """
         if sequence not in self._index:
             self._index[sequence] = {}

--- a/pyrates/sequence.py
+++ b/pyrates/sequence.py
@@ -1,7 +1,7 @@
 """Classes and functions to handle sequence data.
 """
 import pyrates.utils as utils
-import itertools as iter
+import itertools as itools
 
 class SequenceWithQuality(object):
     """A sequence and its quality scores.
@@ -269,7 +269,7 @@ class GroupedSequenceStore(object):
         self._alphabet = alphabet
         self._tag_size = tag_size
         self._store = {''.join(tag):SequenceStore(max_length, alphabet) for
-                       tag in iter.product(alphabet, repeat=tag_size)}
+                       tag in itools.product(alphabet, repeat=tag_size)}
         self._tag_diff = {tag:{other:SequenceStore.diff(tag, other) for
                                other in self._store} for tag in self._store}
         self._wild_store = SequenceStore(max_length, alphabet)
@@ -377,7 +377,7 @@ class GroupedSequenceStore(object):
             ## look for matches with all wildcards replaced
             wilds = [i for (i, letter) in enumerate(tag) if letter == self._wildcard]
             if max_diff > len(wilds):
-                replacements = iter.product(self._alphabet, repeat=len(wilds))
+                replacements = itools.product(self._alphabet, repeat=len(wilds))
                 for replace in replacements:
                     new_seq = list(sequence)
                     for (i, j) in enumerate(wilds):

--- a/pyrates/sequence.py
+++ b/pyrates/sequence.py
@@ -300,7 +300,7 @@ class GroupedSequenceStore(object):
             sequence (:obj:`string`): New sequence to be added.
         """
         tag = sequence[:self._tag_size]
-        if tag not in self:
+        if sequence not in self:
             if self._wildcard is not None and self._wildcard in tag:
                 self._wild_store.add(sequence)
             else:

--- a/pyrates/sequence.py
+++ b/pyrates/sequence.py
@@ -221,7 +221,7 @@ class SequenceStore(object):
             max_count = min(len(self._composition[letter]), letter_count + max_diff + wilds + 1)
             for cand in self._composition[letter][min_count:max_count]:
                 candidates.extend(cand)
-        candidates = set(candidates)
+        candidates = list(set(candidates))
         if raw:
             return candidates
         candidates = [(cand, self.diff(sequence, cand)) for cand in candidates]

--- a/pyrates/sequence.py
+++ b/pyrates/sequence.py
@@ -181,7 +181,7 @@ class SequenceStore(object):
             the number of differences between the returned match and the search string.
             If no suitable match was found `None` is returned instead.
         """
-        match = self.search(sequence, 1, wildcard=wildcard)
+        match = self.search(sequence, max_diff, 1, wildcard=wildcard)
         if len(match) == 0 or match[0][1] > max_diff:
             return None
         return match[0]

--- a/pyrates/sequence.py
+++ b/pyrates/sequence.py
@@ -11,12 +11,13 @@ class SequenceWithQuality(object):
             consisting of ASCII encoded phred scores.
         name (:obj:`str`, optional): Name to use for sequence.
     """
-    __slots__ = '_sequence', '_quality', 'name'
+    __slots__ = '_sequence', '_quality', '_len', 'name'
     def __init__(self, sequence, quality, name=''):
         if len(sequence) != len(quality):
             raise ValueError("Sequence and quality have to have same length.")
         self._sequence = sequence
         self._quality = quality
+        self._len = len(sequence)
         self.name = name
 
     @property
@@ -81,7 +82,7 @@ class SequenceWithQuality(object):
                 (self.sequence, self.quality, self.name)
 
     def __len__(self):
-        return len(self.sequence)
+        return self._len
 
     def __getitem__(self, key):
         return (self._sequence[key], self._quality[key])

--- a/pyrates/test/test_clustering.py
+++ b/pyrates/test/test_clustering.py
@@ -111,7 +111,7 @@ def test_fastq_missing():
            "%r != %r" % (cluster[uid1_expect].sequence.sequence, seq1_expect)
     assert cluster[uid2_expect].sequence.sequence == seq2_expect, \
            "%r != %r" % (cluster[uid2_expect].sequence.sequence, seq2_expect)
-    assert cluster[uid1_expect].size == 4, "%r != %r" % (cluster[uid1_expect].size, 4)
+    assert cluster[uid1_expect].size == 3, "%r != %r" % (cluster[uid1_expect].size, 3)
     assert cluster[uid2_expect].size == 5, "%r != %r" % (cluster[uid2_expect].size, 5)
     assert cluster[uid3_expect].size == 1, "%r != %r" % (cluster[uid2_expect].size, 1)
 

--- a/pyrates/test/test_clustering.py
+++ b/pyrates/test/test_clustering.py
@@ -80,7 +80,26 @@ def test_merge_targets():
 @with_teardown(teardown_fastq_simple)
 def test_fastq_simple():
     """Create consensus from fastq file."""
-    cluster = clust.Clustering.from_fastq(TMP + 'simple.fastq', 4, 'ACGT', threshold=0)
+    cluster = clust.Clustering.from_fastq(TMP + 'simple.fastq', 4, 'ACGT',
+                                          threshold=0, prefix=1)
+    uid1_expect = 'AAAACCCC'
+    uid2_expect = 'CCCCAAAA'
+    seq1_expect = 'ACCTCTCCCTGTGGGTCATGTGACT'
+    seq2_expect = 'TTGTTTGAAAAACCTCGAAAGTAAC'
+
+    assert uid1_expect in cluster, "%r not in %r" % (uid1_expect, list(cluster.keys()))
+    assert uid2_expect in cluster, "%r not in %r" % (uid2_expect, list(cluster.keys()))
+    assert cluster[uid1_expect].sequence.sequence == seq1_expect, \
+           "%r != %r" % (cluster[uid1_expect].sequence.sequence, seq1_expect)
+    assert cluster[uid2_expect].sequence.sequence == seq2_expect, \
+           "%r != %r" % (cluster[uid2_expect].sequence.sequence, seq2_expect)
+
+@with_setup(setup_fastq_simple)
+@with_teardown(teardown_fastq_simple)
+def test_fastq_no_prefix():
+    """Create consensus from fastq file."""
+    cluster = clust.Clustering.from_fastq(TMP + 'simple.fastq', 4, 'ACGT',
+                                          threshold=0, prefix=0)
     uid1_expect = 'AAAACCCC'
     uid2_expect = 'CCCCAAAA'
     seq1_expect = 'ACCTCTCCCTGTGGGTCATGTGACT'
@@ -97,7 +116,8 @@ def test_fastq_simple():
 @with_teardown(teardown_fastq_missing)
 def test_fastq_missing():
     """Create consensus from fastq file."""
-    cluster = clust.Clustering.from_fastq(TMP + 'missing.fastq', 4, 'ACGT', threshold=2)
+    cluster = clust.Clustering.from_fastq(TMP + 'missing.fastq', 4, 'ACGT',
+                                          threshold=2, prefix=1)
     uid1_expect = 'AAAACCCC'
     uid2_expect = 'CCCCAAAA'
     uid3_expect = 'AANAAAAA'
@@ -111,7 +131,7 @@ def test_fastq_missing():
            "%r != %r" % (cluster[uid1_expect].sequence.sequence, seq1_expect)
     assert cluster[uid2_expect].sequence.sequence == seq2_expect, \
            "%r != %r" % (cluster[uid2_expect].sequence.sequence, seq2_expect)
-    assert cluster[uid1_expect].size == 3, "%r != %r" % (cluster[uid1_expect].size, 3)
+    assert cluster[uid1_expect].size == 4, "%r != %r" % (cluster[uid1_expect].size, 4)
     assert cluster[uid2_expect].size == 5, "%r != %r" % (cluster[uid2_expect].size, 5)
     assert cluster[uid3_expect].size == 1, "%r != %r" % (cluster[uid2_expect].size, 1)
 
@@ -119,7 +139,8 @@ def test_fastq_missing():
 @with_teardown(teardown_fastq_map)
 def test_fastq_map():
     """Create consensus from fastq file."""
-    cluster = clust.Clustering.from_fastq(TMP + 'map.fastq', 4, 'ACGT', threshold=2)
+    cluster = clust.Clustering.from_fastq(TMP + 'map.fastq', 4, 'ACGT',
+                                          threshold=2, prefix=1)
     uid1_expect = 'AAAACCCC'
     uid2_expect = 'CCCCAAAA'
     seq1_expect = 'ACCTCTCCCTGTGGGTCATGTGACT'
@@ -142,7 +163,7 @@ def test_fastq_mismatch():
     cluster = clust.Clustering.from_fastq(TMP + 'mismatch.fastq',
                                           id_length=4,
                                           adapter='ACGT',
-                                          threshold=0)
+                                          threshold=0, prefix=1)
     uid1_expect = 'AAAACCCC'
     uid2_expect = 'CCCCAAAA'
     uid3_expect = 'AAAAAAAA'

--- a/pyrates/test/test_clustering.py
+++ b/pyrates/test/test_clustering.py
@@ -70,9 +70,9 @@ def test_merge_targets():
                                 seq1 + seq2, qual1 + qual2)
     seq3 = [pseq.SequenceWithQuality(seq, qual) for seq, qual in zip(seq3, qual3)]
     uid = pseq.SequenceWithQuality(uid2 + uid3, 'I'*(len(uid2) + len(uid3)))
-    cand = clusters.merge_target(uid, seq3[0], {}, 2, None)
+    cand = clusters.merge_target(uid, seq3[0], {}, 2)
     assert cand == uid2 + uid2, "%r != %r" % (cand, uid2 + uid2)
-    cand = clusters.merge_target(uid, seq3[0], {}, 1, None)
+    cand = clusters.merge_target(uid, seq3[0], {}, 1)
     assert cand is None, "%r != %r" % (cand, None)
 
 

--- a/pyrates/test/test_sequence.py
+++ b/pyrates/test/test_sequence.py
@@ -250,34 +250,33 @@ def test_grouped_discard():
     assert "CTGT" not in store, "'CTGT' remains in store after removal"
     assert len(store) == 0, "%r != 0" % len(store)
 
-def test_grouped_search():
+@params((4, 2), (2, 2))
+def test_grouped_search(max_diff, expect_hits):
     """Find all approximate matches"""
-    store = GroupedSequenceStore(4, tag_size=2)
+    store = GroupedSequenceStore(4, max_diff=max_diff, tag_size=2)
     store.add("AAAA")
     store.add("AAAT")
     store.add("AATT")
     store.add("ATTT")
-    match = store.search('TTTT', 4, max_hits=None)
-    assert len(match) == 2, "%r != 2 (found %r)" % (len(match), match)
-    match = store.search('TTTT', 2, max_hits=None)
-    assert len(match) == 2, "%r != 2 (found %r)" % (len(match), match)
+    match = store.search('TTTT', max_hits=None)
+    assert len(match) == expect_hits, "%r != %r (found %r)" % (len(match), expect_hits, match)
 
 @params(('AAAA', ('AAAA', 0)), ('CATT', ('AATT', 1)), ('GGGG', None))
 def test_grouped_find(search, expect):
     """Find best approximate match"""
-    store = GroupedSequenceStore(4, tag_size=2)
+    store = GroupedSequenceStore(4, max_diff=2, tag_size=2)
     store.add("AAAA")
     store.add("AATT")
     store.add("TTTT")
-    match = store.find(search, 2)
+    match = store.find(search)
     assert match == expect, "%r != %r" % (match, expect)
 
 @params(('AANA', ('AAAA', 1)), ('CATT', ('AATT', 1)), ('NGGG', None))
 def test_grouped_find_wild(search, expect):
     """Find best approximate match"""
-    store = GroupedSequenceStore(4, tag_size=2, wildcard='N')
+    store = GroupedSequenceStore(4, max_diff=2, tag_size=2, wildcard='N')
     store.add("AAAA")
     store.add("AATT")
     store.add("TTTT")
-    match = store.find(search, 2)
+    match = store.find(search)
     assert match == expect, "%r != %r" % (match, expect)

--- a/pyrates/test/test_sequence.py
+++ b/pyrates/test/test_sequence.py
@@ -2,7 +2,7 @@
 
 from nose2.tools import params
 from nose2.tools.such import helper
-from pyrates.sequence import SequenceWithQuality, SequenceStore
+from pyrates.sequence import SequenceWithQuality, SequenceStore, GroupedSequenceStore
 
 def test_swq_new():
     """Create sequence objects"""
@@ -104,7 +104,7 @@ def test_store_contains():
     store = SequenceStore(4)
     store.add("AAAA")
     assert "AAAA" in store, "'AAAA' not found in store"
-    assert "AACT" not in store, "'AAAA' remains in store after removal"
+    assert "AACT" not in store, "'AACT' should not be in store"
 
 def test_store_remove():
     """Remove sequences from store"""
@@ -177,4 +177,107 @@ def test_store_list():
     store = SequenceStore.from_list(['AAAA', 'CTGT'])
     assert "AAAA" in store, "'AAAA' not found in store"
     assert "CTGT" in store, "'CTGT' not found in store"
-    
+
+def test_grouped_new():
+    """Create GroupedSequenceStore"""
+    store = GroupedSequenceStore(4, tag_size=2)
+    assert len(store) == 0, "%r != 0" % len(store)
+    assert "AAAA" not in store
+
+def test_grouped_add():
+    """Add entries to GroupedSequenceStore"""
+    store = GroupedSequenceStore(4, tag_size=2)
+    store.add("AAAA")
+    assert len(store) == 1, "%r != 1" % len(store)
+    assert "AAAA" in store
+    store.add("CTGT")
+    assert len(store) == 2, "%r != 2" % len(store)
+    assert "CTGT" in store
+    store.add("CTAA")
+    assert len(store) == 3, "%r != 3" % len(store)
+    assert "CTAA" in store
+
+def test_grouped_add_wild():
+    """Add entries to GroupedSequenceStore"""
+    store = GroupedSequenceStore(4, tag_size=2, wildcard='N')
+    store.add("AAAA")
+    assert len(store) == 1, "%r != 1" % len(store)
+    assert "AAAA" in store
+    store.add("CTNT")
+    assert len(store) == 2, "%r != 2" % len(store)
+    assert "CTNT" in store, "'CTNT' not found in store"
+
+def test_grouped_contains():
+    """Test sequences for membership in GroupedSequenceStore"""
+    store = GroupedSequenceStore(4, tag_size=2, wildcard='N')
+    store.add("AAAA")
+    store.add("NAAA")
+    assert "AAAA" in store, "'AAAA' not found in store"
+    assert "NAAA" in store, "'NAAA' not found in store"
+    assert "AACT" not in store, "'AACT' should not be in store"
+    assert "AANT" not in store, "'AANT' should not be in store"
+
+def test_grouped_remove():
+    """Remove sequences from GroupedSequenceStore"""
+    store = GroupedSequenceStore(4, tag_size=2)
+    store.add("AAAA")
+    store.add("CTGT")
+    assert "AAAA" in store, "'AAAA' not found in store"
+    assert "CTGT" in store, "'CTGT' not found in store"
+    store.remove("AAAA")
+    assert "AAAA" not in store, "'AAAA' remains in store after removal"
+    with helper.assertRaises(KeyError):
+        store.remove("AAAA")
+    assert "CTGT" in store, "'CTGT' not found in store"
+    assert len(store) == 1, "%r != 1" % len(store)
+    store.remove("CTGT")
+    assert "CTGT" not in store, "'CTGT' remains in store after removal"
+    assert len(store) == 0, "%r != 0" % len(store)
+
+def test_grouped_discard():
+    """Discard sequences from GroupedSequenceStore if they exist"""
+    store = GroupedSequenceStore(4, tag_size=2)
+    store.add("AAAA")
+    store.add("CTGT")
+    assert "AAAA" in store, "'AAAA' not found in store"
+    assert "CTGT" in store, "'CTGT' not found in store"
+    store.discard("AAAA")
+    assert "AAAA" not in store, "'AAAA' remains in store after removal"
+    store.discard("AAAA")
+    assert "CTGT" in store, "'CTGT' not found in store"
+    assert len(store) == 1, "%r != 1" % len(store)
+    store.discard("CTGT")
+    assert "CTGT" not in store, "'CTGT' remains in store after removal"
+    assert len(store) == 0, "%r != 0" % len(store)
+
+def test_grouped_search():
+    """Find all approximate matches"""
+    store = GroupedSequenceStore(4, tag_size=2)
+    store.add("AAAA")
+    store.add("AAAT")
+    store.add("AATT")
+    store.add("ATTT")
+    match = store.search('TTTT', 4, max_hits=None)
+    assert len(match) == 2, "%r != 2 (found %r)" % (len(match), match)
+    match = store.search('TTTT', 2, max_hits=None)
+    assert len(match) == 2, "%r != 2 (found %r)" % (len(match), match)
+
+@params(('AAAA', ('AAAA', 0)), ('CATT', ('AATT', 1)), ('GGGG', None))
+def test_grouped_find(search, expect):
+    """Find best approximate match"""
+    store = GroupedSequenceStore(4, tag_size=2)
+    store.add("AAAA")
+    store.add("AATT")
+    store.add("TTTT")
+    match = store.find(search, 2)
+    assert match == expect, "%r != %r" % (match, expect)
+
+@params(('AANA', ('AAAA', 1)), ('CATT', ('AATT', 1)), ('NGGG', None))
+def test_grouped_find_wild(search, expect):
+    """Find best approximate match"""
+    store = GroupedSequenceStore(4, tag_size=2, wildcard='N')
+    store.add("AAAA")
+    store.add("AATT")
+    store.add("TTTT")
+    match = store.find(search, 2)
+    assert match == expect, "%r != %r" % (match, expect)


### PR DESCRIPTION
This provides improvements to the runtime performance of approximate UID matching. To reduce the number of comparisons required for each UID the previously stored UIDs are split into a (short) prefix and the remaining suffix. Differences between all possible prefixes are precomputed and allow for rapid exclusion UIDs if the maximum number of differences between UIDs in the same cluster is smaller than the length of the prefix.