### PR TITLE
Sequence diffs

### DIFF
--- a/pyrates/clustering.py
+++ b/pyrates/clustering.py
@@ -4,7 +4,7 @@
 import logging
 import time
 import datetime
-from collections import defaultdict
+
 import pyrates.utils as utils
 import pyrates.sequence as pseq
 import pyrates.consensus as cons

--- a/pyrates/clustering.py
+++ b/pyrates/clustering.py
@@ -4,7 +4,7 @@
 import logging
 import time
 import datetime
-
+import os.path
 import pyrates.utils as utils
 import pyrates.sequence as pseq
 import pyrates.consensus as cons
@@ -97,7 +97,7 @@ class Clustering(object):
         total_merged = 0
         total_fixed = 0
         single_count = 0
-        name = input_file.split('.')[0]
+        name = os.path.basename(input_file).split('.')[0]
 
         id_set = pseq.GroupedSequenceStore(id_length*2, tag_size=prefix, max_diff=threshold,
                                            wildcard='N')

--- a/pyrates/clustering.py
+++ b/pyrates/clustering.py
@@ -97,6 +97,7 @@ class Clustering(object):
         total_merged = 0
         total_fixed = 0
         single_count = 0
+        name = input_file.split('.')[0]
 
         id_set = pseq.GroupedSequenceStore(id_length*2, tag_size=prefix, max_diff=threshold,
                                            wildcard='N')
@@ -139,7 +140,7 @@ class Clustering(object):
                     qsequence = line[adapt_length:-adapt_length]
 
                     uid = pseq.SequenceWithQuality(nameid, qnameid)
-                    read_seq = pseq.SequenceWithQuality(sequence, qsequence)
+                    read_seq = pseq.SequenceWithQuality(sequence, qsequence, name=name)
                     ## Look for similar IDs that may be candidates for merging
                     similar_id = None
                     if nameid in id_map:

--- a/pyrates/cmd_consensus.py
+++ b/pyrates/cmd_consensus.py
@@ -106,7 +106,7 @@ def main():
         logger.info("Number of sequences that were longer then consensus sequence %d",
                     total_longer)
         logger.info("Number of sequences with ambiguous label %d (%.2f%%)",
-                    seq.fail_count(), seq.fail_count()/len(seq)*100)
+                    seq.fail_count, seq.fail_count/len(seq)*100)
     logger.info('Total time taken: %s', str(datetime.timedelta(seconds=time.time() - started_at)))
     mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
     logger.info('Memory used: %.2f MB', mem)

--- a/pyrates/cmd_consensus.py
+++ b/pyrates/cmd_consensus.py
@@ -106,7 +106,7 @@ def main():
         logger.info("Number of sequences that were longer then consensus sequence %d",
                     total_longer)
         logger.info("Number of sequences with ambiguous label %d (%.2f%%)",
-                    seq.fail_count, seq.fail_count/len(seq)*100)
+                    seq.fail_count, seq.fail_count/float(len(seq))*100)
     logger.info('Total time taken: %s', str(datetime.timedelta(seconds=time.time() - started_at)))
     mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
     logger.info('Memory used: %.2f MB', mem)

--- a/pyrates/cmd_consensus.py
+++ b/pyrates/cmd_consensus.py
@@ -88,7 +88,7 @@ def main():
     seq = clust.Clustering.from_fastq(input_file=args.fastq, id_length=args.id_length,
                                       adapter=args.adapter, threshold=args.id_tolerance,
                                       prefix=args.prefix_length)
-    seq.write(args.output_file)
+    seq.write(args.output)
     if logger.isEnabledFor(logging.INFO):
         total_different = 0
         total_shorter = 0

--- a/pyrates/cmd_consensus.py
+++ b/pyrates/cmd_consensus.py
@@ -88,7 +88,7 @@ def main():
     seq = clust.Clustering.from_fastq(input_file=args.fastq, id_length=args.id_length,
                                       adapter=args.adapter, threshold=args.id_tolerance,
                                       prefix=args.prefix_length)
-
+    seq.write(args.output_file)
     if logger.isEnabledFor(logging.INFO):
         total_different = 0
         total_shorter = 0

--- a/pyrates/consensus.py
+++ b/pyrates/consensus.py
@@ -192,13 +192,16 @@ class Consensus(object):
     def __str__(self):
         diff_str = ''
         diff_pos = sorted(self.diffs)
+        diff_str = []
         for pos in diff_pos:
-            diff_str += " " + str(pos)
+            pos_diff = str(pos+1)
             for nuc in sorted(self.diffs[pos]):
-                diff_str += nuc + str(self.diffs[pos][nuc])
-        return "@%d%s\n%s%s\n+\n%s%s" % (self.size, diff_str, self.uid.sequence,
-                                         self.sequence.sequence, self.uid.quality,
-                                         self.sequence.quality)
+                pos_diff += nuc + str(self.diffs[pos][nuc])
+            diff_str.append(pos_diff)
+        diff_str = ' '.join(diff_str)
+        return "@%d\n%s%s\n+%s\n%s%s" % (self.size, self.uid.sequence,
+                                         self.sequence.sequence, diff_str,
+                                         self.uid.quality, self.sequence.quality)
 
     def __repr__(self):
         return "Consensus(uid=%r, sequence=%r, diffs=%r, size=%r)" % \

--- a/pyrates/consensus.py
+++ b/pyrates/consensus.py
@@ -199,12 +199,12 @@ class Consensus(object):
                 pos_diff += nuc + str(self.diffs[pos][nuc])
             diff_str.append(pos_diff)
         diff_str = ' '.join(diff_str)
-        return "@%s:%s:%d:%d:%d:%d\n%s%s\n+%s\n%s%s" % (self.sequence.name,
-                                                        self.uid.sequence, self.size,
-                                                        self.shorter, self.longer, self.different,
-                                                        self.uid.sequence,
-                                                        self.sequence.sequence, diff_str,
-                                                        self.uid.quality, self.sequence.quality)
+        return "@%s:%s:%s:%d:%d:%d:%d\n%s\n+%s\n%s" % (self.sequence.name,
+                                                       self.uid.sequence, self.uid.quality,
+                                                       self.size, self.shorter, self.longer,
+                                                       self.different,
+                                                       self.sequence.sequence, diff_str,
+                                                       self.sequence.quality)
 
     def __repr__(self):
         return "Consensus(uid=%r, sequence=%r, diffs=%r, size=%r)" % \

--- a/pyrates/consensus.py
+++ b/pyrates/consensus.py
@@ -199,9 +199,12 @@ class Consensus(object):
                 pos_diff += nuc + str(self.diffs[pos][nuc])
             diff_str.append(pos_diff)
         diff_str = ' '.join(diff_str)
-        return "@%d\n%s%s\n+%s\n%s%s" % (self.size, self.uid.sequence,
-                                         self.sequence.sequence, diff_str,
-                                         self.uid.quality, self.sequence.quality)
+        return "@%s:%s:%d:%d:%d:%d\n%s%s\n+%s\n%s%s" % (self.sequence.name,
+                                                        self.uid.sequence, self.size,
+                                                        self.shorter, self.longer, self.different,
+                                                        self.uid.sequence,
+                                                        self.sequence.sequence, diff_str,
+                                                        self.uid.quality, self.sequence.quality)
 
     def __repr__(self):
         return "Consensus(uid=%r, sequence=%r, diffs=%r, size=%r)" % \

--- a/pyrates/sequence.py
+++ b/pyrates/sequence.py
@@ -1,7 +1,8 @@
 """Classes and functions to handle sequence data.
 """
-import pyrates.utils as utils
 import itertools as itools
+
+import pyrates.utils as utils
 
 class SequenceWithQuality(object):
     """A sequence and its quality scores.

--- a/pyrates/test/test_clustering.py
+++ b/pyrates/test/test_clustering.py
@@ -46,10 +46,10 @@ def test_merge_diff(idx):
     for i in range(1, len(clusters)):
         success = merged.merge(centres[i], 2)
         assert success
-    expect = "@12 7G5T7 9A1C9G2"
+    expect = "+8G5T7 10A1C9G2"
     obs = str(merged).splitlines()
     assert merged.size == 12, "%r != %r" % (merged.size, 12)
-    assert obs[0] == expect, "%r != %r" % (obs[0], expect)
+    assert obs[2] == expect, "%r != %r" % (obs[2], expect)
 
 def test_merge_targets():
     """Identify cluster for merging"""

--- a/pyrates/test/test_consensus.py
+++ b/pyrates/test/test_consensus.py
@@ -122,16 +122,16 @@ def test_consensus_diff():
 def test_consensus_str():
     """String representation of consensus sequences"""
     id1 = sequence.SequenceWithQuality("AAAA", "IIII")
-    seq1 = sequence.SequenceWithQuality("ACTGTTTGTCTAAGC", "IIIDIIIIIIIIIII")
-    seq2 = sequence.SequenceWithQuality("ACTTTTTGTCTTAGC", "IIIIIIIIIDIDIII")
+    seq1 = sequence.SequenceWithQuality("ACTGTTTGTCTAAGC", "IIIDIIIIIIIIIII", name='test')
+    seq2 = sequence.SequenceWithQuality("ACTTTTTGTCTTAGC", "IIIIIIIIIDIDIII", name='test')
     consensus = cons.Consensus(id1, seq1)
-    expect_str1 = "@1\nAAAAACTGTTTGTCTAAGC\n+\nIIIIIIIDIIIIIIIIIII"
+    expect_str1 = "@test:AAAA:1:0:0:0\nAAAAACTGTTTGTCTAAGC\n+\nIIIIIIIDIIIIIIIIIII"
     expect_repr1 = "Consensus(uid=SequenceWithQuality(sequence='AAAA', " + \
                                                      "quality='IIII', name=''), " + \
                    "sequence=SequenceWithQuality(sequence='ACTGTTTGTCTAAGC', " + \
-                                                "quality='IIIDIIIIIIIIIII', name=''), " + \
+                                                "quality='IIIDIIIIIIIIIII', name='test'), " + \
                    "diffs={}, size=1)"
-    expect_str2 = "@2\nAAAAACTTTTTGTCTAAGC\n+4G1T1 12A1T1\nIIIIIIIIIIIIIIIIIII"
+    expect_str2 = "@test:AAAA:2:0:0:0\nAAAAACTTTTTGTCTAAGC\n+4G1T1 12A1T1\nIIIIIIIIIIIIIIIIIII"
 
     assert str(consensus) == expect_str1, "\n%s\n!=\n%s" % (consensus, expect_str1)
     assert repr(consensus) == expect_repr1, "\n%r\n!=\n%r" % (consensus, expect_repr1)

--- a/pyrates/test/test_consensus.py
+++ b/pyrates/test/test_consensus.py
@@ -131,7 +131,7 @@ def test_consensus_str():
                    "sequence=SequenceWithQuality(sequence='ACTGTTTGTCTAAGC', " + \
                                                 "quality='IIIDIIIIIIIIIII', name=''), " + \
                    "diffs={}, size=1)"
-    expect_str2 = "@2 3G1T1 11A1T1\nAAAAACTTTTTGTCTAAGC\n+\nIIIIIIIIIIIIIIIIIII"
+    expect_str2 = "@2\nAAAAACTTTTTGTCTAAGC\n+4G1T1 12A1T1\nIIIIIIIIIIIIIIIIIII"
 
     assert str(consensus) == expect_str1, "\n%s\n!=\n%s" % (consensus, expect_str1)
     assert repr(consensus) == expect_repr1, "\n%r\n!=\n%r" % (consensus, expect_repr1)

--- a/pyrates/test/test_consensus.py
+++ b/pyrates/test/test_consensus.py
@@ -125,13 +125,13 @@ def test_consensus_str():
     seq1 = sequence.SequenceWithQuality("ACTGTTTGTCTAAGC", "IIIDIIIIIIIIIII", name='test')
     seq2 = sequence.SequenceWithQuality("ACTTTTTGTCTTAGC", "IIIIIIIIIDIDIII", name='test')
     consensus = cons.Consensus(id1, seq1)
-    expect_str1 = "@test:AAAA:1:0:0:0\nAAAAACTGTTTGTCTAAGC\n+\nIIIIIIIDIIIIIIIIIII"
+    expect_str1 = "@test:AAAA:IIII:1:0:0:0\nACTGTTTGTCTAAGC\n+\nIIIDIIIIIIIIIII"
     expect_repr1 = "Consensus(uid=SequenceWithQuality(sequence='AAAA', " + \
                                                      "quality='IIII', name=''), " + \
                    "sequence=SequenceWithQuality(sequence='ACTGTTTGTCTAAGC', " + \
                                                 "quality='IIIDIIIIIIIIIII', name='test'), " + \
                    "diffs={}, size=1)"
-    expect_str2 = "@test:AAAA:2:0:0:0\nAAAAACTTTTTGTCTAAGC\n+4G1T1 12A1T1\nIIIIIIIIIIIIIIIIIII"
+    expect_str2 = "@test:AAAA:IIII:2:0:0:0\nACTTTTTGTCTAAGC\n+4G1T1 12A1T1\nIIIIIIIIIIIIIII"
 
     assert str(consensus) == expect_str1, "\n%s\n!=\n%s" % (consensus, expect_str1)
     assert repr(consensus) == expect_repr1, "\n%r\n!=\n%r" % (consensus, expect_repr1)


### PR DESCRIPTION
A number of tweaks to how information about consensus sequences is encoded in fastq output files.

* Coordinates of sequence differences are now 1-based.
* Sequence diffs are reported on the third line of the record to avoid excessively long read names.
* Add a name to the beginning of the read name field. When using the CLI this is derived from the name of  
  the input file, using the part of the file name that precedes the first '.'.
* New format for the read name field:
  `<name>:<uid>:<uid quality>:<cluster size>:<short>:<long>:<different>`
  where 
    *  *name* is the sample name derived from the input file
    * *uid* is the UID sequence
    * *uid quality* is the string of (ASCII encoded) phred scores for the UID sequence
    * *cluster size* is the total number of reads assigned to this cluster
    * *short* is the number of sequences that didn't contribute to the consensus because they were too 
       short
    * *long* is the number of sequences that didn't contribute to the consensus because they were too long
    * *different* is the number of sequences that didn't contribute to the consensus because they were
       considered to be too different.

I'm not sure that storing the UID in the name field is really ideal but it does have the advantage that the UID will propagate to the BAM file without interfering with read mapping. It also ensures that read names are unique.